### PR TITLE
購入情報登録機能実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 |  city          |  string      |  null: false        |
 |  block_number  |  string      |  null: false        |
 |  building      |  string      |  -----------        |
-|  phone_number  |  string     |  null: false        |
+|  phone_number  |  string      |  null: false        |
 |  order         |  references  |  foreign_key: true  |
 ・belongs_to:order
 

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the orders controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,0 @@
-class ItemsController < ApplicationController
-
-  def index
-  end
-
-end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,7 @@
 class OrdersController < ApplicationController
-  before_action :set_order
-  before_action :authenticate_user!
-  before_action :move_to_index
+  before_action :set_order, only: [:index, :create]
+  before_action :authenticate_user!, only: [:index, :create]
+  before_action :move_to_index, only: [:index, :create]
   
 
   def index

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,35 @@
+class OrdersController < ApplicationController
+  before_action :set_order
+  before_action :authenticate_user!
+  before_action :move_to_index
+  
+
+  def index
+    @order = Order.new
+    @order_address = OrderAddress.new
+  end
+
+  def create
+    @order_address = OrderAddress.new(order_params)
+    if @order_address.valid?
+        @order_address.save
+        redirect_to root_path
+    else
+       render 'orders/index'
+    end
+  end
+
+  private
+  
+  def order_params
+    params.require(:order_address).permit(:zip_code,:prefecture_id,:city,:block_number,:building,:phone_number).merge(user_id: current_user.id,product_id: params[:product_id],token: params[:token])
+  end
+
+  def set_order
+    @product = Product.find(params[:product_id])
+  end
+
+  def move_to_index
+    redirect_to root_path if current_user.id == @product.user.id && @product.order.present?
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -30,6 +30,6 @@ class OrdersController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path if current_user.id == @product.user.id && @product.order.present?
+    redirect_to root_path if current_user.id == @product.user.id || @product.order.present?
   end
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,5 @@
 class Order < ApplicationRecord
-  #belongs_to :user
-  #belongs_to :product
+  belongs_to :user
+  belongs_to :product
+  has_one    :address
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -3,6 +3,8 @@ class OrderAddress
   attr_accessor :product_id, :user_id,:zip_code, :prefecture_id, :city, :block_number, :building, :phone_number , :token
 
   with_options presence: true do
+    validates :product_id
+    validates :user_id
     validates :zip_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
     validates :city
     validates :block_number
@@ -10,6 +12,8 @@ class OrderAddress
     with_options numericality: { other_than: 1 } do
       validates :prefecture_id
     end
+    validates :token
+    validates :phone_number, numericality: { only_integer: true }
   end
 
   def save

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,21 @@
+class OrderAddress
+  include ActiveModel::Model
+  attr_accessor :product_id, :user_id,:zip_code, :prefecture_id, :city, :block_number, :building, :phone_number , :token
+
+  with_options presence: true do
+    validates :zip_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :city
+    validates :block_number
+    validates :phone_number, length: { minimum: 10, maximum: 11 }
+    with_options numericality: { other_than: 1 } do
+      validates :prefecture_id
+    end
+  end
+
+  def save
+    @order = Order.create(product_id: product_id, user_id: user_id)
+
+    Address.create(zip_code: zip_code, prefecture_id: prefecture_id, city: city, block_number: block_number, building: building,
+                   phone_number: phone_number, order_id: @order.id)
+  end
+end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @product.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @product.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @product.price %></p>
+          <p class='item-price-sub-text'><%= @product.charge.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,13 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @product.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: [@product, @order_address], url: product_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -82,42 +83,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field 'hoge', class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :zip_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Area.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field 'hoge', class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field 'hoge', class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :block_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field 'hoge', class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field 'hoge', class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && @product.order.nil? %>
       <% if @product.user_id == current_user.id %>
         <% if @product.order.blank? %>
           <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -32,7 +32,7 @@
           <% end %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%= link_to "購入画面に進む", product_orders_path(@product.id), method: :get ,class:"item-red-btn"%>
       <%# //商品が売れていない場合はこちらを表示しましょう %>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products
+  resources :products do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20210627033842_create_addresses.rb
+++ b/db/migrate/20210627033842_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :zip_code        , null:false
+      t.integer    :prefecture_id   , null:false
+      t.string     :city            , null:false
+      t.string     :block_number    , null:false
+      t.string     :building        
+      t.string     :phone_number    , null:false
+      t.references :order           , null:false ,foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_13_042149) do
+ActiveRecord::Schema.define(version: 2021_06_27_033842) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,19 @@ ActiveRecord::Schema.define(version: 2021_06_13_042149) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "zip_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "block_number", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
   end
 
   create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -101,6 +114,7 @@ ActiveRecord::Schema.define(version: 2021_06_13_042149) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "orders", "products"
   add_foreign_key "orders", "users"
   add_foreign_key "products", "users"

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     block_number { '1-1' }
     building { '東京ハイツ' }
     phone_number { '09010101010' }
+    token { 'tok_abcdefghijk00000000000000000' }
   end
 end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order_address do
+    zip_code { '123-4567' }
+    prefecture_id { 2 }
+    city { '東京都' }
+    block_number { '1-1' }
+    building { '東京ハイツ' }
+    phone_number { '09010101010' }
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
   RSpec.describe OrderAddress, type: :model do
     describe '購入情報情報の保存' do
       before do
-        @order_address = FactoryBot.build(:order_address)
+        user = FactoryBot.create(:user)
+        product = FactoryBot.create(:product)
+        @order_address = FactoryBot.build(:order_address, user_id: user.id, product_id: product.id)
+        sleep 0.1 
       end
 
       context '内容に問題ない場合' do
@@ -51,6 +54,26 @@ require 'rails_helper'
           @order_address.phone_number = '090'
           @order_address.valid?
           expect(@order_address.errors.full_messages).to include('Phone number is too short (minimum is 10 characters)')
+        end
+        it 'phone_numberは英数字混同では保存できないこと' do
+          @order_address.phone_number = '0901111aaaa'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Phone number is not a number')
+        end
+        it 'userが紐付いていないと保存できないこと' do
+          @order_address.user_id = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("User can't be blank")
+        end
+        it 'tokenが空では登録できないこと' do
+          @order_address.token = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Token can't be blank")
+        end
+        it 'productが紐付いていないと保存できないこと' do
+          @order_address.product_id = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Product can't be blank")
         end
       end
     end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+  RSpec.describe OrderAddress, type: :model do
+    describe '購入情報情報の保存' do
+      before do
+        @order_address = FactoryBot.build(:order_address)
+      end
+
+      context '内容に問題ない場合' do
+        it 'すべての値が正しく入力されていれば保存できること' do
+          expect(@order_address).to be_valid
+        end
+        it 'buildingは空でも保存できること' do
+          @order_address.building = ''
+          expect(@order_address).to be_valid
+        end
+      end
+
+      context '内容に問題がある場合' do
+        it 'zip_codeが空だと保存できないこと' do
+          @order_address.zip_code = ''
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Zip code can't be blank", "Zip code is invalid. Include hyphen(-)")
+        end
+        it 'zip_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
+          @order_address.zip_code = '1234567'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Zip code is invalid. Include hyphen(-)")
+        end
+        it 'prefectureを選択していないと保存できないこと' do
+          @order_address.prefecture_id = 1
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Prefecture must be other than 1")
+        end
+        it 'cityが空だと保存できないこと' do
+          @order_address.city = ''
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("City can't be blank")
+        end
+        it 'block_numberが空だと保存できないこと' do
+          @order_address.block_number = ''
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Block number can't be blank")
+        end
+        it 'phone_numberが空だと保存できないこと' do
+          @order_address.phone_number = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+        end
+        it 'phone_numberが11桁未満では保存できないこと' do
+          @order_address.phone_number = '090'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Phone number is too short (minimum is 10 characters)')
+        end
+      end
+    end
+  end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# Whta
購入情報登録機能を作成

# What
購入情報登録機能を実装するため

- 購入に成功する動画
https://gyazo.com/d9b60d06eaedcf7f273e7308182b960f

- 購入が完了したら、トップページまたは購入完了ページに遷移する動画
https://gyazo.com/d9b60d06eaedcf7f273e7308182b960f

- 購入に失敗してエラーが表示させる動画
https://gyazo.com/2b19b13707c2c6fbcc5cae027b78170b

- ログアウト状態のユーザーが商品購入ページに遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/7619ba363916bc9ec60dd60037767f37

- ログイン状態の出品者が、URLを直接入力して自身の出品した商品購入ページに遷移しようとすると、トップページに遷移する動画
https://gyazo.com/bfad5d42461a46210e6369951ab513d3

- ログインユーザーがURLを直接入力して売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
- https://gyazo.com/806cfb1991e56163ad23b4223b650211


- 出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画(編集機能要件より)
https://gyazo.com/ed40ae4893dc8bb4d585b8d7fff5f7bb


- ログアウト状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画(編集機能要件より)
https://gyazo.com/600d6f993985918b07e1af57a0fa5c6a


- ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されない動画（詳細機能要件より)
https://gyazo.com/5a712e59917572edd66f7931793857ad

- テスト結果の画像
https://gyazo.com/5f679c893507a44880e45f150cb01f74